### PR TITLE
Integrate JaCoCo code coverage reports and upload to codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+# Each virtual machine has the same hardware resources available.
+#
+# - 2-core CPU
+# - 7 GB of RAM memory
+# - 14 GB of SSD disk space
+#
+# https://help.github.com/en/actions/automating-your-workflow-with-github-actions/virtual-environments-for-github-hosted-runners
+
+name: CI
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-16.04
+    env:
+      GRADLE_ARGS: >-
+        --stacktrace
+        --no-daemon
+        --max-workers 2
+        -Pkotlin.incremental=false
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2-beta
+
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Gradle cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.gradle
+          key: grade-${{ hashFiles('**/build.gradle') }}
+
+      - name: Check
+        run: ./gradlew $GRADLE_ARGS check
+
+      - name: JaCoCo Test Report
+        run: ./gradlew $GRADLE_ARGS jacocoTestDebugUnitTestReport
+
+      - name: Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![codecov](https://codecov.io/gh/JuulLabs-OSS/stropping/branch/master/graph/badge.svg)](https://codecov.io/gh/JuulLabs-OSS/stropping)
+
 # Stropping
 
 **Stropping** performs reflection on Dagger.

--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,7 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$versions.kotlin"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:0.10.0"
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
+        classpath 'com.dicedmelon.gradle:jacoco-android:0.1.4'
     }
 }
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'maven-publish'
 apply plugin: 'org.jetbrains.dokka'
 apply plugin: 'com.github.dcendents.android-maven'
+apply from: rootProject.file('gradle/jacoco-android.gradle')
 
 group=metadata.groupId
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'maven-publish'
 apply plugin: 'org.jetbrains.dokka'
-apply plugin: 'com.github.dcendents.android-maven'
+apply from: rootProject.file('gradle/jacoco-android.gradle')
 
 group=metadata.groupId
 

--- a/gradle/jacoco-android.gradle
+++ b/gradle/jacoco-android.gradle
@@ -1,0 +1,11 @@
+apply plugin: 'jacoco-android'
+
+jacoco {
+    toolVersion = "0.8.5"
+}
+
+jacocoAndroidUnitTestReport {
+    csv.enabled false
+    html.enabled true
+    xml.enabled true
+}

--- a/kodein/build.gradle
+++ b/kodein/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'maven-publish'
 apply plugin: 'org.jetbrains.dokka'
 apply plugin: 'com.github.dcendents.android-maven'
+apply from: rootProject.file('gradle/jacoco-android.gradle')
 
 group=metadata.groupId
 


### PR DESCRIPTION
JaCoCo code coverage reports can be generated locally using:

```
./gradlew jacocoTestReport
```

Adds codecov badge to [README](https://github.com/JuulLabs-OSS/stropping/blob/twyatt/codecov/README.md) (which should update once this PR is merged):

![Screen Shot 2020-01-29 at 5 09 09 PM](https://user-images.githubusercontent.com/98017/73411425-24626580-42ba-11ea-9b91-3d2741761d6e.png)