### PR TITLE
Kotlin object support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
                     min    : 21,
                     target : 29,
             ],
-            stropping : '0.1.1',
+            stropping : '0.1.2',
     ]
     ext.deps = [
             androidx : [

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,3 @@
 rootProject.name = 'Stropping'
 include ':stropping',
         ':example'
-

--- a/stropping/src/main/java/com/juul/stropping/Graph.kt
+++ b/stropping/src/main/java/com/juul/stropping/Graph.kt
@@ -1,9 +1,13 @@
 package com.juul.stropping
 
+import android.util.Log
 import dagger.Component
 import dagger.Module
 import dagger.android.ContributesAndroidInjector
 import java.lang.reflect.Method
+import kotlin.reflect.full.companionObject
+
+private const val TAG = "Stropping.Graph"
 
 /**
  * Entry point for reflection over a Dagger graph.
@@ -24,7 +28,13 @@ class Graph(componentClass: Class<*>) {
     val includedClasses: Set<Class<*>> by lazy {
         val classes = mutableSetOf<Class<*>>()
         fun addClassAndIncludes(clazz: Class<*>) {
+            Log.v(TAG, "Include class: ${clazz.canonicalName}")
             classes += clazz
+            val companion = clazz.kotlin.companionObject
+            if (companion != null) {
+                classes += companion.java
+                Log.v(TAG, "Include class: ${companion.java.canonicalName}")
+            }
             val componentAnnotation = clazz.findAnnotation<Component>()
             val moduleAnnotation = clazz.findAnnotation<Module>()
             val directlyIncludedClasses = arrayOf(
@@ -47,7 +57,7 @@ class Graph(componentClass: Class<*>) {
     }
 
     /** The [Provisioner]s found in [includedClasses]. */
-    val provisioners: List<Provisioner> by lazy {
+    val provisioners: List<MethodProvisioner> by lazy {
         declaredMethods
             .mapNotNull { Provisioner.fromMethod(it) }
             .toList()


### PR DESCRIPTION
- Verbose logs for initial Dagger bindings
- Dependency graph now includes companion objects
- Object instances are now used when available
- Version incremented to 0.1.2

Doesn't include tests yet because this was implemented on a deadline 😓 